### PR TITLE
Support Basic Push Flags

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,7 +9,6 @@
         "@typescript-eslint"
     ],
     "rules": {
-        "@typescript-eslint/naming-convention": "warn",
         "@typescript-eslint/semi": "warn",
         "curly": "warn",
         "eqeqeq": "warn",

--- a/README.md
+++ b/README.md
@@ -8,14 +8,12 @@ Use Push to Gerrit to push.
 
 ## Requirements
 
-If you have any requirements or dependencies, add a section describing those and how to install and configure them.
+You must have git installed.
 
 ## Extension Settings
 
 This extension contributes the following settings:
-None Yet.
-<!-- * `myExtension.enable`: Enable/disable this extension.
-* `myExtension.thing`: Set to `blah` to do something. -->
+* `gerrit-tools.push.defaultPushOption`: Specifies the default push option to be used, can always be changed on every push.
 
 ## Known Issues
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,24 @@
         "command": "gerrit-tools.pushToGerrit",
         "title": "Push to Gerrit"
       }
-    ]
+    ],
+    "configuration": {
+      "title": "Gerrit Tools",
+      "properties": {
+        "gerrit-tools.push.defaultPushOption": {
+          "description": "Specifies the first option when the prompt for when pushing",
+          "type": "string",
+          "default": "None",
+          "enum": [
+            "None",
+            "Work in Progress",
+            "Private",
+            "Remove Work in Progress",
+            "Remove Private"
+          ]
+        }
+      }
+    }
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -72,7 +72,7 @@ function getCurrentBranch(path: string): string {
 	return result.toString().trimStart().trimEnd().replace("origin/", "");
 }
 
-function makeQuickPick(branches: string[]): vscode.QuickPickItem[] {
+function makeBranchesQuickPick(branches: string[]): vscode.QuickPickItem[] {
 	let list: vscode.QuickPickItem[] = [];
 	branches = branches.sort(function (a, b) { return a.localeCompare(b); });
 	branches.forEach(branch => {
@@ -90,7 +90,7 @@ function push(path: string) {
 	const list = getOriginBranches(path);
 	currentBranch = getCurrentBranch(path);
 
-	vscode.window.showQuickPick(makeQuickPick(list), { canPickMany: false, title: "Select the branch to push to" }).then(branch => {
+	vscode.window.showQuickPick(makeBranchesQuickPick(list), { canPickMany: false, title: "Select the branch to push to" }).then(branch => {
 		if (branch !== undefined) {
 			const branchName: string = branch!.label;
 			const pushString: string[] = ["push", "origin", "HEAD:refs/for/" + branchName.replace(ICON, "")];


### PR DESCRIPTION
Close #1 

There are many different push flags that can be added with Gerrit but this adds the two major ones: WIP and Private.
There is a setting for setting the default value to allow for ever faster pushing. Currently only one option is allowed as allowing more is a lot harder from a UX perspective.